### PR TITLE
Resolve dependency installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
-    "@radix-ui/react-button": "^1.0.3",
     "@radix-ui/react-card": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",


### PR DESCRIPTION
Remove `@radix-ui/react-button` dependency because it does not exist in the npm registry and caused a `404 Not Found` error during `pnpm install`.

---
<a href="https://cursor.com/background-agent?bcId=bc-93aa382a-be72-47b9-b950-e2dbdbcb4b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93aa382a-be72-47b9-b950-e2dbdbcb4b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

